### PR TITLE
Properly name each artifact in GH Actions.

### DIFF
--- a/.github/workflows/example-local.yml
+++ b/.github/workflows/example-local.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
+          name: salsa.txt
           path: salsa.txt
 
   generate-provenance:
@@ -38,4 +39,5 @@ jobs:
       - name: Upload provenance
         uses: actions/upload-artifact@v2
         with:
+          name: build.provenance
           path: build.provenance

--- a/.github/workflows/example-publish.yml
+++ b/.github/workflows/example-publish.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
+          name: salsa.txt
           path: salsa.txt
 
   generate-provenance:
@@ -33,4 +34,5 @@ jobs:
       - name: Upload provenance
         uses: actions/upload-artifact@v2
         with:
+          name: build.provenance
           path: build.provenance


### PR DESCRIPTION
Previously both the artifact (salsa.txt) and the provenance
(build.provenance) were uploaded with the default name of "artifact",
meaning that the provenance overwrote the original artifact.
