### PR TITLE
Revert "Properly name each artifact in GH Actions."

### DIFF
--- a/.github/workflows/example-local.yml
+++ b/.github/workflows/example-local.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: salsa.txt
           path: salsa.txt
 
   generate-provenance:
@@ -39,5 +38,4 @@ jobs:
       - name: Upload provenance
         uses: actions/upload-artifact@v2
         with:
-          name: build.provenance
           path: build.provenance

--- a/.github/workflows/example-publish.yml
+++ b/.github/workflows/example-publish.yml
@@ -15,7 +15,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: salsa.txt
           path: salsa.txt
 
   generate-provenance:
@@ -34,5 +33,4 @@ jobs:
       - name: Upload provenance
         uses: actions/upload-artifact@v2
         with:
-          name: build.provenance
           path: build.provenance


### PR DESCRIPTION
This reverts commit f293d1cd68f0b3457dbf3f4f793e9f9cadd5efa1.

An "artifact" in GitHub Actions is a collection of files, not a single
file, so the original version was working fine (with all files under the
collection named "artifact") whereas the new version broke because it
tried to download the non-existent artifact named "artifact".

Let's just revert to the old version because it was fine.
