### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+:warning: **This repository is deprecated. Please see [slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) for a more complete solution for GitHub Actions.** :warning:
+
 # SLSA GitHub Actions Demo
 
 A proof-of-concept SLSA provenance generator for GitHub Actions.
@@ -40,17 +42,17 @@ The GitHub action has the following user configuration
 
 | Input           | Default            | Description                                            |
 | --------------- | ------------------ | ------------------------------------------------------ |
-| `artifact_path` | *`none`*           | Path to build artifact or directory of build artifacts |
+| `artifact_path` | _`none`_           | Path to build artifact or directory of build artifacts |
 | `output_path`   | `build.provenance` | Path to write build provenance file                    |
 
 To try out this provenance generator, add the following snippet to your GitHub
 Actions workflow:
 
 ```yaml
-      - name: Generate provenance
-        uses: slsa-framework/github-actions-demo@v0.1
-        with:
-          artifact_path: <path-to-artifact>
+- name: Generate provenance
+  uses: slsa-framework/github-actions-demo@v0.1
+  with:
+    artifact_path: <path-to-artifact>
 ```
 
 In this example we use the default output path `build.provenance`, you can
@@ -58,9 +60,9 @@ upload the build provenance to the workflow run result with the
 `actions/upload-artifact` github action
 
 ```yaml
-      - name: Upload provenance
-        uses: actions/upload-artifact@v2
-        with:
-          name: my-artifact
-          path: build.provenance
+- name: Upload provenance
+  uses: actions/upload-artifact@v2
+  with:
+    name: my-artifact
+    path: build.provenance
 ```

--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ The GitHub action has the following user configuration
 
 | Input           | Default            | Description                                            |
 | --------------- | ------------------ | ------------------------------------------------------ |
-| `artifact_path` | _`none`_           | Path to build artifact or directory of build artifacts |
+| `artifact_path` | *`none`*           | Path to build artifact or directory of build artifacts |
 | `output_path`   | `build.provenance` | Path to write build provenance file                    |
 
 To try out this provenance generator, add the following snippet to your GitHub
 Actions workflow:
 
 ```yaml
-- name: Generate provenance
-  uses: slsa-framework/github-actions-demo@v0.1
-  with:
-    artifact_path: <path-to-artifact>
+      - name: Generate provenance
+        uses: slsa-framework/github-actions-demo@v0.1
+        with:
+          artifact_path: <path-to-artifact>
 ```
 
 In this example we use the default output path `build.provenance`, you can
@@ -60,9 +60,9 @@ upload the build provenance to the workflow run result with the
 `actions/upload-artifact` github action
 
 ```yaml
-- name: Upload provenance
-  uses: actions/upload-artifact@v2
-  with:
-    name: my-artifact
-    path: build.provenance
+      - name: Upload provenance
+        uses: actions/upload-artifact@v2
+        with:
+          name: my-artifact
+          path: build.provenance
 ```


### PR DESCRIPTION
It was brought up that this repository can be confusing for new users wanting to get started with SLSA on GitHub actions. The feedback we got was that it was better to have a single repository for GitHub Actions and that it would be better to direct users to [slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) as it is better maintained.

After this PR is merged we can archive this repository.

/cc @diogoteles08

Signed-off-by: Ian Lewis <ianmlewis@gmail.com>